### PR TITLE
Fix broken link

### DIFF
--- a/src/routes/main-menu.svelte
+++ b/src/routes/main-menu.svelte
@@ -69,7 +69,7 @@
 			<a
 				id="youtube"
 				class="group/link flex flex-row h-full w-full p-2 focus:outline-none focus:bg-[#313346] gap-2 items-center justify-between hover:bg-[#313346]"
-				href="https://youtube.com/dmmulroy"
+				href="https://www.youtube.com/@dmmulroy"
 				target="_blank"
 			>
 				<span class="flex flex-row gap-4 items-center"


### PR DESCRIPTION
Link lead to a 404 page for me,

- from https://youtube.com/dmmulroy
- to https://www.youtube.com/@dmmulroy

![image](https://github.com/user-attachments/assets/8210da05-8999-4c05-a05f-f6ee0cbb3aff)
